### PR TITLE
Add `meta.type` "problem"

### DIFF
--- a/packages/eslint-plugin-ecmascript-compat/lib/rule.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/rule.js
@@ -5,6 +5,7 @@ const targetRuntimes = require('./targetRuntimes');
 
 module.exports = {
   meta: {
+    type: 'problem',
     schema: [], // no options
   },
   create(context) {


### PR DESCRIPTION
`meta.type` can be used with fixable rules by using `eslint --fix-type` (per https://eslint.org/docs/user-guide/command-line-interface#fix-type ).

However, my personal interest is for an eslint badge formatter I'm working on which can count total violations by `meta.type` (i.e., "problem", "suggestion", or "layout").