### PR TITLE
Prevent running CI twice on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: Node CI
 
 on:
   push:
+    branches:
+      - 'master'
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
Push and synchronize are overlapping