### PR TITLE
Complete ES2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It doesn't check browser/runtime-specific APIs (see [eslint-plugin-compat](https
 
 ## ECMAScript version coverage
 
-- ✅ [ES2020](https://v8.dev/features/tags/es2020) (draft)
+- ✅ [ES2020](https://v8.dev/features/tags/es2020)
 - ✅ [ES2019](https://flaviocopes.com/es2019)<sup>1, 2</sup>
 - ✅ [ES2018](https://flaviocopes.com/es2018)
 - ✅ [ES2017](https://flaviocopes.com/es2017)

--- a/packages/eslint-plugin-ecmascript-compat-example/src/app.js
+++ b/packages/eslint-plugin-ecmascript-compat-example/src/app.js
@@ -1,5 +1,5 @@
 /**
- * ES2020
+ * ES2020 (all implemented, but these examples not complete)
  */
 foo = 100n;
 BigInt(100);

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es-versions.md
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es-versions.md
@@ -10,7 +10,7 @@ Static detectability of recently-added features
 
 | Name                                | ESLint / eslint-plugin-es          | Chrome since |
 | ----------------------------------- | ---------------------------------- | ------------ |
-| `Atomics.{notify, wait, waitAsync}` | ❌                                 | 68           |
+| `Atomics.{notify, wait, waitAsync}` | no-restricted-properties           | 68           |
 | `BigInt`                            | es/no-bigint                       | 67           |
 | Dynamic `import()`                  | es/no-dynamic-import               | 63           |
 | `globalThis`                        | es/no-global-this                  | 71           |

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es-versions.md
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es-versions.md
@@ -8,18 +8,18 @@ Static detectability of recently-added features
 
 ### ES2020
 
-| Name                                | ESLint / eslint-plugin-es          | Chrome since |
-| ----------------------------------- | ---------------------------------- | ------------ |
-| `Atomics.{notify, wait, waitAsync}` | no-restricted-properties           | 68           |
-| `BigInt`                            | es/no-bigint                       | 67           |
-| Dynamic `import()`                  | es/no-dynamic-import               | 63           |
-| `globalThis`                        | es/no-global-this                  | 71           |
-| `import.meta`                       | es/no-import-meta                  | 64           |
-| Module namespace exports            | es/no-export-ns-from               | 72           |
-| Nullish coalescing (`??`)           | es/no-nullish-coalescing-operators | 80           |
-| Optional chaining (`?.`)            | es/no-optional-chaining            | 80           |
-| `Promise.allSettled`                | es/no-promise-all-settled          | 76           |
-| `String.prototype.matchAll`         | 😐 no-restricted-syntax            | 73           |
+| Name                        | ESLint / eslint-plugin-es          | Chrome since |
+| --------------------------- | ---------------------------------- | ------------ |
+| `Atomics.{notify, wait}`    | no-restricted-properties           | 68           |
+| `BigInt`                    | es/no-bigint                       | 67           |
+| Dynamic `import()`          | es/no-dynamic-import               | 63           |
+| `globalThis`                | es/no-global-this                  | 71           |
+| `import.meta`               | es/no-import-meta                  | 64           |
+| Module namespace exports    | es/no-export-ns-from               | 72           |
+| Nullish coalescing (`??`)   | es/no-nullish-coalescing-operators | 80           |
+| Optional chaining (`?.`)    | es/no-optional-chaining            | 80           |
+| `Promise.allSettled`        | es/no-promise-all-settled          | 76           |
+| `String.prototype.matchAll` | 😐 no-restricted-syntax            | 73           |
 
 ### ES2019
 

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es-versions.md
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es-versions.md
@@ -6,15 +6,20 @@ Static detectability of recently-added features
 - 😐 = statically detectable, but chance of false positives
 - 👎 = statically detectable, but not worth the false positives
 
-### ES2020 (draft)
+### ES2020
 
-| Name                        | ESLint / eslint-plugin-es | Chrome since |
-| --------------------------- | ------------------------- | ------------ |
-| `BigInt`                    | es/no-bigint              | 67           |
-| Dynamic `import()`          | es/no-dynamic-import      | 63           |
-| `globalThis`                | no-restricted-globals     | 71           |
-| `Promise.allSettled`        | es/no-promise-all-settled | 76           |
-| `String.prototype.matchAll` | 😐 no-restricted-syntax   | 73           |
+| Name                                | ESLint / eslint-plugin-es          | Chrome since |
+| ----------------------------------- | ---------------------------------- | ------------ |
+| `Atomics.{notify, wait, waitAsync}` | ❌                                 | 68           |
+| `BigInt`                            | es/no-bigint                       | 67           |
+| Dynamic `import()`                  | es/no-dynamic-import               | 63           |
+| `globalThis`                        | no-restricted-globals              | 71           |
+| `import.meta`                       | es/no-import-meta                  | 64           |
+| Module namespace exports            | es/no-export-ns-from               | 72           |
+| Nullish coalescing (`??`)           | es/no-nullish-coalescing-operators | 80           |
+| Optional chaining (`?.`)            | es/no-optional-chaining            | 80           |
+| `Promise.allSettled`                | es/no-promise-all-settled          | 76           |
+| `String.prototype.matchAll`         | 😐 no-restricted-syntax            | 73           |
 
 ### ES2019
 

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es-versions.md
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es-versions.md
@@ -13,7 +13,7 @@ Static detectability of recently-added features
 | `Atomics.{notify, wait, waitAsync}` | ❌                                 | 68           |
 | `BigInt`                            | es/no-bigint                       | 67           |
 | Dynamic `import()`                  | es/no-dynamic-import               | 63           |
-| `globalThis`                        | no-restricted-globals              | 71           |
+| `globalThis`                        | es/no-global-this                  | 71           |
 | `import.meta`                       | es/no-import-meta                  | 64           |
 | Module namespace exports            | es/no-export-ns-from               | 72           |
 | Nullish coalescing (`??`)           | es/no-nullish-coalescing-operators | 80           |

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es-versions.md
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es-versions.md
@@ -53,8 +53,8 @@ Static detectability of recently-added features
 | ------------------------------------- | -------------------------------------- | ------------ |
 | Async functions                       | es/no-async-functions                  | 55           |
 | Atomics                               | es/no-atomics                          | 68           |
-| `Object.getOwnPropertyDescriptors`    | es/no-object-getownpropertydescriptors | 54           |
 | `Object.entries`                      | es/no-object-entries                   | 54           |
+| `Object.getOwnPropertyDescriptors`    | es/no-object-getownpropertydescriptors | 54           |
 | `Object.values`                       | es/no-object-values                    | 54           |
 | SharedArrayBuffer                     | es/no-shared-array-buffer              | 68           |
 | `String.prototype.{padStart, padEnd}` | 😐 no-restricted-syntax                | 57           |

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.js
@@ -7,6 +7,20 @@ const coreRules = new eslint.Linter().getRules();
 
 module.exports = [
   {
+    ruleConfig: {
+      definition: coreRules.get('no-restricted-properties'),
+      options: [{ object: 'Atomics', property: 'notify', message: '(ES2020)' }],
+    },
+    compatFeatures: [compatData.javascript.builtins.Atomics.notify],
+  },
+  {
+    ruleConfig: {
+      definition: coreRules.get('no-restricted-properties'),
+      options: [{ object: 'Atomics', property: 'wait', message: '(ES2020)' }],
+    },
+    compatFeatures: [compatData.javascript.builtins.Atomics.wait],
+  },
+  {
     ruleConfig: { definition: esPlugin.rules['no-bigint'] },
     compatFeatures: [compatData.javascript.builtins.BigInt],
   },

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.js
@@ -23,6 +23,10 @@ module.exports = [
     compatFeatures: [compatData.javascript.statements.import_meta],
   },
   {
+    ruleConfig: { definition: esPlugin.rules['no-export-ns-from'] },
+    compatFeatures: [compatData.javascript.statements.export.namespace],
+  },
+  {
     // Rule requires the ES6 global, Promise
     ruleConfig: { definition: esPlugin.rules['no-promise-all-settled'] },
     compatFeatures: [compatData.javascript.builtins.Promise.allSettled],

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.js
@@ -31,6 +31,10 @@ module.exports = [
     compatFeatures: [compatData.javascript.operators.nullish_coalescing],
   },
   {
+    ruleConfig: { definition: esPlugin.rules['no-optional-chaining'] },
+    compatFeatures: [compatData.javascript.operators.optional_chaining],
+  },
+  {
     // Rule requires the ES6 global, Promise
     ruleConfig: { definition: esPlugin.rules['no-promise-all-settled'] },
     compatFeatures: [compatData.javascript.builtins.Promise.allSettled],

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.js
@@ -15,15 +15,7 @@ module.exports = [
     compatFeatures: [compatData.javascript.statements.import.dynamic_import],
   },
   {
-    ruleConfig: {
-      definition: coreRules.get('no-restricted-globals'),
-      options: [
-        {
-          name: 'globalThis',
-          message: "ES2020 global 'globalThis' is forbidden",
-        },
-      ],
-    },
+    ruleConfig: { definition: esPlugin.rules['no-global-this'] },
     compatFeatures: [compatData.javascript.builtins.globalThis],
   },
   {

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.js
@@ -19,6 +19,10 @@ module.exports = [
     compatFeatures: [compatData.javascript.builtins.globalThis],
   },
   {
+    ruleConfig: { definition: esPlugin.rules['no-import-meta'] },
+    compatFeatures: [compatData.javascript.statements.import_meta],
+  },
+  {
     // Rule requires the ES6 global, Promise
     ruleConfig: { definition: esPlugin.rules['no-promise-all-settled'] },
     compatFeatures: [compatData.javascript.builtins.Promise.allSettled],

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.js
@@ -27,6 +27,10 @@ module.exports = [
     compatFeatures: [compatData.javascript.statements.export.namespace],
   },
   {
+    ruleConfig: { definition: esPlugin.rules['no-nullish-coalescing-operators'] },
+    compatFeatures: [compatData.javascript.operators.nullish_coalescing],
+  },
+  {
     // Rule requires the ES6 global, Promise
     ruleConfig: { definition: esPlugin.rules['no-promise-all-settled'] },
     compatFeatures: [compatData.javascript.builtins.Promise.allSettled],

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.spec.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.spec.js
@@ -49,6 +49,10 @@ ruleTester.run('compat', require('../rule'), {
       errors: [{ message: "ES2020 'export * as ns' are forbidden." }],
     },
     {
+      code: 'foo ?? fallback',
+      errors: [{ message: 'ES2020 nullish coalescing operators are forbidden.' }],
+    },
+    {
       code: 'Promise.allSettled();',
       errors: [{ message: "ES2020 'Promise.allSettled' function is forbidden." }],
     },

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.spec.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.spec.js
@@ -12,6 +12,9 @@ const ruleTester = new RuleTester({
     // ES2020 global, required by es/no-bigint
     BigInt: 'readonly',
 
+    // ES2020 global, required by es/no-global-this
+    globalThis: 'readonly',
+
     // ES6 global, required by es/no-promise-all-settled
     Promise: 'readonly',
   },
@@ -34,12 +37,7 @@ ruleTester.run('compat', require('../rule'), {
     },
     {
       code: 'globalThis.foo;',
-      errors: [
-        {
-          message:
-            "Unexpected use of 'globalThis'. ES2020 global 'globalThis' is forbidden",
-        },
-      ],
+      errors: [{ message: "ES2020 'globalThis' variable is forbidden." }],
     },
     {
       code: 'Promise.allSettled();',

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.spec.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.spec.js
@@ -25,6 +25,14 @@ ruleTester.run('compat', require('../rule'), {
   valid: [],
   invalid: [
     {
+      code: 'Atomics.notify();',
+      errors: [{ message: "'Atomics.notify' is restricted from being used. (ES2020)" }],
+    },
+    {
+      code: 'Atomics.wait();',
+      errors: [{ message: "'Atomics.wait' is restricted from being used. (ES2020)" }],
+    },
+    {
       code: 'const foo = 100n;',
       errors: [{ message: 'ES2020 BigInt is forbidden.' }],
     },

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.spec.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.spec.js
@@ -7,6 +7,7 @@ jest.resetModules();
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 2020,
+    sourceType: 'module', // import.meta can only be used in an ES module
   },
   globals: {
     // ES2020 global, required by es/no-bigint
@@ -38,6 +39,10 @@ ruleTester.run('compat', require('../rule'), {
     {
       code: 'globalThis.foo;',
       errors: [{ message: "ES2020 'globalThis' variable is forbidden." }],
+    },
+    {
+      code: 'import.meta;',
+      errors: [{ message: "ES2020 'import.meta' meta property is forbidden." }],
     },
     {
       code: 'Promise.allSettled();',

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.spec.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.spec.js
@@ -7,7 +7,7 @@ jest.resetModules();
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 2020,
-    sourceType: 'module', // import.meta can only be used in an ES module
+    sourceType: 'module', // import.meta and namespace exports can only be used in an ES module
   },
   globals: {
     // ES2020 global, required by es/no-bigint
@@ -43,6 +43,10 @@ ruleTester.run('compat', require('../rule'), {
     {
       code: 'import.meta;',
       errors: [{ message: "ES2020 'import.meta' meta property is forbidden." }],
+    },
+    {
+      code: 'export * as nmspace from "./other";',
+      errors: [{ message: "ES2020 'export * as ns' are forbidden." }],
     },
     {
       code: 'Promise.allSettled();',

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.spec.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.spec.js
@@ -53,6 +53,10 @@ ruleTester.run('compat', require('../rule'), {
       errors: [{ message: 'ES2020 nullish coalescing operators are forbidden.' }],
     },
     {
+      code: 'fooMaybe?.something',
+      errors: [{ message: 'ES2020 optional chaining is forbidden.' }],
+    },
+    {
       code: 'Promise.allSettled();',
       errors: [{ message: "ES2020 'Promise.allSettled' function is forbidden." }],
     },

--- a/packages/eslint-plugin-ecmascript-compat/package-lock.json
+++ b/packages/eslint-plugin-ecmascript-compat/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.8.0",
-				"eslint-plugin-es": "^2.0.0",
+				"eslint-plugin-es": "^4.1.0",
 				"lodash": "^4.17.21",
 				"mdn-browser-compat-data": "^1.0.25"
 			},
@@ -2113,15 +2113,18 @@
 			}
 		},
 		"node_modules/eslint-plugin-es": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz",
-			"integrity": "sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+			"integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
 			"dependencies": {
-				"eslint-utils": "^1.4.2",
+				"eslint-utils": "^2.0.0",
 				"regexpp": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=8.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
 			},
 			"peerDependencies": {
 				"eslint": ">=4.19.1"
@@ -2140,20 +2143,23 @@
 			}
 		},
 		"node_modules/eslint-utils": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+			"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
 			"dependencies": {
 				"eslint-visitor-keys": "^1.1.0"
 			},
 			"engines": {
 				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
 			"engines": {
 				"node": ">=4"
 			}
@@ -7776,11 +7782,11 @@
 			}
 		},
 		"eslint-plugin-es": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz",
-			"integrity": "sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+			"integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
 			"requires": {
-				"eslint-utils": "^1.4.2",
+				"eslint-utils": "^2.0.0",
 				"regexpp": "^3.0.0"
 			}
 		},
@@ -7794,17 +7800,17 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+			"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
 			"requires": {
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
 		},
 		"espree": {
 			"version": "9.3.0",

--- a/packages/eslint-plugin-ecmascript-compat/package.json
+++ b/packages/eslint-plugin-ecmascript-compat/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "browserslist": "^4.8.0",
-    "eslint-plugin-es": "^2.0.0",
+    "eslint-plugin-es": "^4.1.0",
     "lodash": "^4.17.21",
     "mdn-browser-compat-data": "^1.0.25"
   },


### PR DESCRIPTION
Support all the features - fixes #32

Includes update of eslint-plugin-es (task #40), but more work is needed to probably use its prototype methods rather than our own.