### PR TITLE
Compare versions correctly (#30)

### DIFF
--- a/packages/eslint-plugin-ecmascript-compat/lib/compatibility.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/compatibility.js
@@ -1,5 +1,7 @@
 /* eslint-disable camelcase, no-underscore-dangle */
 
+const compareVersions = require('compare-versions').compare;
+
 function forbiddenFeatures(features, targets) {
   return features.filter((feature) => !isFeatureSupportedByTargets(feature, targets));
 }
@@ -30,7 +32,7 @@ function isCompatFeatureSupportedByTarget(compatFeature, target) {
     return true;
   }
 
-  return !support.isNone && target.version >= versionAdded;
+  return !support.isNone && compareVersions(target.version, versionAdded, '>=');
 }
 
 function getSimpleSupportStatement(compatFeature, target) {

--- a/packages/eslint-plugin-ecmascript-compat/package-lock.json
+++ b/packages/eslint-plugin-ecmascript-compat/package-lock.json
@@ -6,11 +6,12 @@
 	"packages": {
 		"": {
 			"name": "eslint-plugin-ecmascript-compat",
-			"version": "1.1.1",
+			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"@mdn/browser-compat-data": "^4.1.3",
 				"browserslist": "^4.8.0",
+				"compare-versions": "^4.1.3",
 				"eslint-plugin-es": "^4.1.0",
 				"lodash": "^4.17.21"
 			},
@@ -1823,6 +1824,11 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/compare-versions": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-4.1.3.tgz",
+			"integrity": "sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg=="
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -7421,6 +7427,11 @@
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
+		},
+		"compare-versions": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-4.1.3.tgz",
+			"integrity": "sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg=="
 		},
 		"concat-map": {
 			"version": "0.0.1",

--- a/packages/eslint-plugin-ecmascript-compat/package.json
+++ b/packages/eslint-plugin-ecmascript-compat/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@mdn/browser-compat-data": "^4.1.3",
     "browserslist": "^4.8.0",
+    "compare-versions": "^4.1.3",
     "eslint-plugin-es": "^4.1.0",
     "lodash": "^4.17.21"
   },


### PR DESCRIPTION
`eslint-plugin-ecmascript-compat` currently compares version number strings with the `>=` operator, which only yields expected results if each component (major/minor/patch) of both version numbers is the same number of digits, meaning the plugin doesn't work in many cases. For example, the plugin currently considers `9.0.0` to be a higher version number than `10.0.0`. This patch adds proper version comparison.