### PR TITLE
fix: version compare

### DIFF
--- a/packages/eslint-plugin-ecmascript-compat/lib/compatibility.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/compatibility.js
@@ -30,7 +30,7 @@ function isCompatFeatureSupportedByTarget(compatFeature, target) {
     return true;
   }
 
-  return !support.isNone && target.version >= versionAdded;
+  return !support.isNone && compareVersions(target.version, versionAdded) >= 0;
 }
 
 function getSimpleSupportStatement(compatFeature, target) {
@@ -52,6 +52,31 @@ function interpretSupport(versionAdded) {
     isNone: versionAdded === false,
     isVersionUnknown: versionAdded === true,
   };
+}
+
+// the code generate by chatGPT
+// support all version types obtained from the browserslist. (npx browserslist  '>=0%')
+// 1. a.b.c
+// 2. a.b.c-d.e.f
+// 3. all
+function compareVersions(version1, version2) {
+  function getVersionNumber(version) {
+    if (version === 'all') {
+      return Infinity;
+    }
+    // discard version after "-"
+    const match = version.match(/^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\-\d+\.\d+)?$/);
+    if (!match) {
+      return 0;
+    }
+    const major = Number(match[1]) * 1000000000;
+    const minor = Number(match[2] || 0) * 1000000;
+    const patch = Number(match[3] || 0) * 1000;
+    return major + minor + patch;
+  }
+  const v1 = getVersionNumber(version1.split('-')[0]);
+  const v2 = getVersionNumber(version2.split('-')[0]);
+  return v1 > v2 ? 1 : v1 < v2 ? -1 : 0;
 }
 
 module.exports = { unsupportedFeatures };

--- a/packages/eslint-plugin-ecmascript-compat/lib/compatibility.spec.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/compatibility.spec.js
@@ -194,3 +194,29 @@ it('explains what the problem is when compat feature not found in MDN data', () 
     unsupportedFeatures([feature], [{ name: 'chrome', version: '73' }]);
   }).toThrow("Sparse compatFeatures for rule 'some rule': object,undefined");
 });
+
+it('version compare', () => {
+  const feature = {
+    compatFeatures: [
+      {
+        __compat: {
+          support: {
+            chrome: [
+              { version_added: '49' },
+            ],
+          },
+        },
+      },
+    ],
+  };
+  function getUnsupportedFeaturesByChromeVersion(version) {
+    return unsupportedFeatures(
+      [feature],
+      [{ name: 'chrome', version }]
+    )
+  }
+  expect(getUnsupportedFeaturesByChromeVersion('9')).toHaveLength(1);
+  expect(getUnsupportedFeaturesByChromeVersion('100')).toHaveLength(0);
+  expect(getUnsupportedFeaturesByChromeVersion('100-101')).toHaveLength(0);
+  expect(getUnsupportedFeaturesByChromeVersion('all')).toHaveLength(0);
+});


### PR DESCRIPTION
The current implementation logic will have problems when comparing two string versions：
<img width="887" alt="image" src="https://user-images.githubusercontent.com/3899648/224491911-7afa3f79-55dc-4fd7-b7fb-7e808b27fdf5.png">
