### PR TITLE
Update to v5 of MDN database

### DIFF
--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2018.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2018.js
@@ -30,11 +30,11 @@ module.exports = [
   },
   {
     ruleConfig: { definition: esPlugin.rules['no-regexp-lookbehind-assertions'] },
-    compatFeatures: [compatData.javascript.builtins.RegExp.lookbehind_assertion],
+    compatFeatures: [compatData.javascript.regular_expressions.lookbehind_assertion],
   },
   {
     ruleConfig: { definition: esPlugin.rules['no-regexp-named-capture-groups'] },
-    compatFeatures: [compatData.javascript.builtins.RegExp.named_capture_groups],
+    compatFeatures: [compatData.javascript.regular_expressions.named_capturing_group],
   },
   {
     ruleConfig: { definition: esPlugin.rules['no-regexp-s-flag'] },
@@ -49,6 +49,8 @@ module.exports = [
        */
       definition: esPlugin.rules['no-regexp-unicode-property-escapes'],
     },
-    compatFeatures: [compatData.javascript.builtins.RegExp.property_escapes],
+    compatFeatures: [
+      compatData.javascript.regular_expressions.unicode_character_class_escape,
+    ],
   },
 ];

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2020.js
@@ -26,7 +26,7 @@ module.exports = [
   },
   {
     ruleConfig: { definition: esPlugin.rules['no-dynamic-import'] },
-    compatFeatures: [compatData.javascript.statements.import.dynamic_import],
+    compatFeatures: [compatData.javascript.operators.import],
   },
   {
     ruleConfig: { definition: esPlugin.rules['no-global-this'] },
@@ -35,7 +35,7 @@ module.exports = [
   },
   {
     ruleConfig: { definition: esPlugin.rules['no-import-meta'] },
-    compatFeatures: [compatData.javascript.statements.import_meta],
+    compatFeatures: [compatData.javascript.operators.import_meta],
   },
   {
     ruleConfig: { definition: esPlugin.rules['no-export-ns-from'] },

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2021.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2021.js
@@ -19,7 +19,7 @@ module.exports = [
     compatFeatures: [
       compatData.javascript.operators.logical_or_assignment,
       compatData.javascript.operators.logical_and_assignment,
-      compatData.javascript.operators.logical_nullish_assignment,
+      compatData.javascript.operators.nullish_coalescing_assignment,
     ],
   },
   {

--- a/packages/eslint-plugin-ecmascript-compat/package-lock.json
+++ b/packages/eslint-plugin-ecmascript-compat/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "2.2.0",
 			"license": "MIT",
 			"dependencies": {
-				"@mdn/browser-compat-data": "^4.1.3",
+				"@mdn/browser-compat-data": "^5.2.55",
 				"browserslist": "^4.8.0",
 				"eslint-plugin-es-x": "^5.4.0",
 				"lodash": "^4.17.21"
@@ -1201,9 +1201,9 @@
 			}
 		},
 		"node_modules/@mdn/browser-compat-data": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.3.tgz",
-			"integrity": "sha512-489a7ook3U/LZtFAw4c713LgQa/hTVMUdWPmrUHox+gF/xbR01EQkJfSjiVeKPGS8SQtnkcHyuiBkIwRZZaYlQ=="
+			"version": "5.2.55",
+			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.55.tgz",
+			"integrity": "sha512-V5y5VhgXobwZl817zn+iAlCSTbXIXBMRHbL2WDyjJyMMgcHZoQTk6db1y3ZxBUo/H23MXgTKBo7bQ9S8aEfs2A=="
 		},
 		"node_modules/@sinonjs/commons": {
 			"version": "1.8.3",
@@ -6911,9 +6911,9 @@
 			}
 		},
 		"@mdn/browser-compat-data": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.3.tgz",
-			"integrity": "sha512-489a7ook3U/LZtFAw4c713LgQa/hTVMUdWPmrUHox+gF/xbR01EQkJfSjiVeKPGS8SQtnkcHyuiBkIwRZZaYlQ=="
+			"version": "5.2.55",
+			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.55.tgz",
+			"integrity": "sha512-V5y5VhgXobwZl817zn+iAlCSTbXIXBMRHbL2WDyjJyMMgcHZoQTk6db1y3ZxBUo/H23MXgTKBo7bQ9S8aEfs2A=="
 		},
 		"@sinonjs/commons": {
 			"version": "1.8.3",

--- a/packages/eslint-plugin-ecmascript-compat/package.json
+++ b/packages/eslint-plugin-ecmascript-compat/package.json
@@ -36,7 +36,7 @@
     "test": "jest --env=node"
   },
   "dependencies": {
-    "@mdn/browser-compat-data": "^4.1.3",
+    "@mdn/browser-compat-data": "^5.2.55",
     "browserslist": "^4.8.0",
     "eslint-plugin-es-x": "^5.4.0",
     "lodash": "^4.17.21"


### PR DESCRIPTION
Breaking changes found by unit test trial and error (then searched release notes for cause):

regular_expressions - #19050 in v5.2.54
import - #16766 in v5.1.3, #16720 in v5.1.2
nullish - #18700 in v5.2.31

Resolves #59 