### PR TITLE
Add browserslist options to the rule options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,38 +57,6 @@ It doesn't check browser/runtime-specific APIs (see [eslint-plugin-compat](https
 
 We use a pinned version of `@mdn/browser-compat-data`, because their [SemVer policy](https://github.com/mdn/browser-compat-data#semantic-versioning-policy) allows for breaking changes to the data structure even in minor and patch releases. If you need to use more up to date data, use the `overrides` facility of `package.json` to specify a later version - but be aware that it might break.
 
-## Options
-
-### polyfills
-
-Example:
-
-```
-    'ecmascript-compat/compat': ['error', { polyfills: ['Object.hasOwn'] }]
-```
-
-A array of provided polyfills can be provided in order to not warn about polyfilled features.
-
-### overrideBrowserslist
-
-Example:
-
-```
-    'ecmascript-compat/compat': ['error', { overrideBrowserslist: 'IE >= 11' }]
-```
-
-You can override the browsers list config to a custom definition instead of the default behaviour to find a browsers list file or property in a package.json.
-
-### browserslistOptions
-
-Example:
-
-```
-    'ecmascript-compat/compat': ['error', { browserslistOptions: { env: 'legacy' } }]
-```
-
-You can specify the options provided to browsers list, for example the environment name. See [browserslist API options](https://github.com/browserslist/browserslist#js-api).
-
 ## Limitations
 
 Because JavaScript is untyped, detection of some features' usage (namely prototype methods) through static analysis requires some assumptions to be made. This shouldn't be a problem as long as you avoid creating your own methods having the same names, or write code in an unusual way to deliberately evade detection.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,38 @@ It doesn't check browser/runtime-specific APIs (see [eslint-plugin-compat](https
 
 We use a pinned version of `@mdn/browser-compat-data`, because their [SemVer policy](https://github.com/mdn/browser-compat-data#semantic-versioning-policy) allows for breaking changes to the data structure even in minor and patch releases. If you need to use more up to date data, use the `overrides` facility of `package.json` to specify a later version - but be aware that it might break.
 
+## Options
+
+### polyfills
+
+Example:
+
+```
+    'ecmascript-compat/compat': ['error', { polyfills: ['Object.hasOwn'] }]
+```
+
+A array of provided polyfills can be provided in order to not warn about polyfilled features.
+
+### overrideBrowserslist
+
+Example:
+
+```
+    'ecmascript-compat/compat': ['error', { overrideBrowserslist: 'IE >= 11' }]
+```
+
+You can override the browsers list config to a custom definition instead of the default behaviour to find a browsers list file or property in a package.json.
+
+### browserslistOptions
+
+Example:
+
+```
+    'ecmascript-compat/compat': ['error', { browserslistOptions: { env: 'legacy' } }]
+```
+
+You can specify the options provided to browsers list, for example the environment name. See [browserslist API options](https://github.com/browserslist/browserslist#js-api).
+
 ## Limitations
 
 Because JavaScript is untyped, detection of some features' usage (namely prototype methods) through static analysis requires some assumptions to be made. This shouldn't be a problem as long as you avoid creating your own methods having the same names, or write code in an unusual way to deliberately evade detection.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ We use a pinned version of `@mdn/browser-compat-data`, because their [SemVer pol
 
 Because JavaScript is untyped, detection of some features' usage (namely prototype methods) through static analysis requires some assumptions to be made. This shouldn't be a problem as long as you avoid creating your own methods having the same names, or write code in an unusual way to deliberately evade detection.
 
-The MDN compatibility dataset has very good coverage of the top ~6 desktop and mobile browsers, and Node.js (much more than [kangax/compat-table](https://github.com/kangax/compat-table)). In case of missing data (support unknown, or unknown in which version support was added), we currently assume support.
+Support can only be checked for the [browsers and runtimes covered](https://github.com/mdn/browser-compat-data/tree/main/browsers) by the MDN compatibility dataset.
+
+The MDN compatibility dataset has very good feature coverage of the top ~6 desktop and mobile browsers, and Node.js (much more than [kangax/compat-table](https://github.com/kangax/compat-table)). In case of missing data for a feature (support unknown, or unknown in which version support was added), we currently assume support.
 
 ## Contributing
 

--- a/packages/eslint-plugin-ecmascript-compat/README.md
+++ b/packages/eslint-plugin-ecmascript-compat/README.md
@@ -28,7 +28,7 @@ npm install --save-dev eslint-plugin-ecmascript-compat
         "polyfills": [
           "Array.prototype.includes"
         ],
-        // Optionally, override the browserslist config in the ESLint config
+        // Optionally, provide a browserslist to use instead of the project one
         "overrideBrowserslist": "IE >= 11",
         // Optionally, specify browserslist options - see https://github.com/browserslist/browserslist#js-api
         "browserslistOptions": { "env": "legacy" }

--- a/packages/eslint-plugin-ecmascript-compat/README.md
+++ b/packages/eslint-plugin-ecmascript-compat/README.md
@@ -27,7 +27,11 @@ npm install --save-dev eslint-plugin-ecmascript-compat
         // Optionally, specify provided polyfills
         "polyfills": [
           "Array.prototype.includes"
-        ]
+        ],
+        // Optionally, override the browsers list config in the eslint config
+        "overrideBrowserslist": "IE >= 11",
+        // Optionally, provide browserslist options - see https://github.com/browserslist/browserslist#js-api
+        "browserslistOptions": { "env": "legacy" }
       }
     ]
   }

--- a/packages/eslint-plugin-ecmascript-compat/README.md
+++ b/packages/eslint-plugin-ecmascript-compat/README.md
@@ -28,7 +28,7 @@ npm install --save-dev eslint-plugin-ecmascript-compat
         "polyfills": [
           "Array.prototype.includes"
         ],
-        // Optionally, override the browsers list config in the eslint config
+        // Optionally, override the browserslist config in the ESLint config
         "overrideBrowserslist": "IE >= 11",
         // Optionally, provide browserslist options - see https://github.com/browserslist/browserslist#js-api
         "browserslistOptions": { "env": "legacy" }

--- a/packages/eslint-plugin-ecmascript-compat/README.md
+++ b/packages/eslint-plugin-ecmascript-compat/README.md
@@ -30,7 +30,7 @@ npm install --save-dev eslint-plugin-ecmascript-compat
         ],
         // Optionally, override the browserslist config in the ESLint config
         "overrideBrowserslist": "IE >= 11",
-        // Optionally, provide browserslist options - see https://github.com/browserslist/browserslist#js-api
+        // Optionally, specify browserslist options - see https://github.com/browserslist/browserslist#js-api
         "browserslistOptions": { "env": "legacy" }
       }
     ]

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2022.spec.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2022.spec.js
@@ -1,9 +1,5 @@
 const { RuleTester } = require('eslint');
 
-// Browser that doesn't support any features of this version - see es-versions.md
-process.env.BROWSERSLIST = 'Chrome >= 71';
-jest.resetModules();
-
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 2022,
@@ -11,83 +7,84 @@ const ruleTester = new RuleTester({
   },
 });
 
+const chrome71Options = { overrideBrowserslist: 'Chrome >= 71' };
+const chrome90Options = { overrideBrowserslist: 'Chrome >= 90' };
+
 ruleTester.run('compat', require('../rule'), {
   valid: [
     {
       code: '[].at(1);',
-      options: [{ polyfills: ['{Array,String,TypedArray}.prototype.at'] }],
+      options: [
+        { ...chrome71Options, polyfills: ['{Array,String,TypedArray}.prototype.at'] },
+      ],
     },
     {
       code: '"Foo".at(1);',
-      options: [{ polyfills: ['{Array,String,TypedArray}.prototype.at'] }],
+      options: [
+        { ...chrome71Options, polyfills: ['{Array,String,TypedArray}.prototype.at'] },
+      ],
     },
     {
       code: "new Error('message', { cause: originalError })",
-      options: [{ polyfills: ['Error.cause'] }],
+      options: [{ ...chrome71Options, polyfills: ['Error.cause'] }],
     },
     {
       code: "Object.hasOwn(obj, 'prop');",
-      options: [{ polyfills: ['Object.hasOwn'] }],
+      options: [{ ...chrome71Options, polyfills: ['Object.hasOwn'] }],
     },
   ],
   invalid: [
     {
       // Obvious array, doesn't need aggressive mode
       code: '[].at(1);',
+      options: [chrome71Options],
       errors: [{ message: "ES2022 'Array.prototype.at' method is forbidden." }],
     },
     {
       // Obvious string, doesn't need aggressive mode
       code: '"Foo".at(1);',
+      options: [chrome71Options],
       errors: [{ message: "ES2022 'String.prototype.at' method is forbidden." }],
     },
     {
       // Not obvious, needs aggressive mode
       code: 'foo.at(1);',
+      options: [chrome71Options],
       errors: [{ message: "ES2022 'Array.prototype.at' method is forbidden." }],
     },
     {
       code: 'class A { a = 0 }',
+      options: [chrome71Options],
       errors: [{ message: "ES2020 field 'a' is forbidden." }],
     },
     {
       code: 'class A { static { } }',
+      options: [chrome71Options],
       errors: [{ message: 'ES2022 class static block is forbidden.' }],
     },
     {
       code: "new Error('message', { cause: originalError })",
+      options: [chrome71Options],
       errors: [{ message: 'ES2022 Error Cause is forbidden.' }],
     },
     {
       code: "Object.hasOwn(obj, 'prop');",
+      options: [chrome71Options],
       errors: [{ message: "ES2022 'Object.hasOwn' method is forbidden." }],
     },
     {
       code: '/./d;',
+      options: [chrome71Options],
       errors: [{ message: "ES2022 RegExp 'd' flag is forbidden." }],
     },
     {
       code: 'await true;',
+      options: [chrome71Options],
       errors: [{ message: "ES2022 top-level 'await' is forbidden." }],
     },
-  ],
-});
-
-// Browser that supports private fields but not `in` on them - see es-versions.md
-process.env.BROWSERSLIST = 'Chrome >= 90';
-jest.resetModules();
-
-const ruleTester2 = new RuleTester({
-  parserOptions: {
-    ecmaVersion: 2022,
-  },
-});
-
-ruleTester2.run('compat', require('../rule'), {
-  valid: [],
-  invalid: [
     {
       code: 'class A { #field; foo() { #field in this; } }',
+      options: [chrome90Options],
       errors: [{ message: 'ES2022 private in (`#field in object`) is forbidden.' }],
     },
   ],

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2022.spec.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2022.spec.js
@@ -1,15 +1,15 @@
 const { RuleTester } = require('eslint');
 
+// Browser that doesn't support any features of this version - see es-versions.md
+process.env.BROWSERSLIST = 'Chrome >= 71';
+jest.resetModules();
+
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 2022,
     sourceType: 'module', // top level await can only be used in an ES module
   },
 });
-
-// Browser that doesn't support any features of this version - see es-versions.md
-process.env.BROWSERSLIST = 'Chrome >= 71';
-jest.resetModules();
 
 ruleTester.run('compat', require('../rule'), {
   valid: [
@@ -72,6 +72,7 @@ ruleTester.run('compat', require('../rule'), {
     },
     {
       code: 'class A { #field; foo() { #field in this; } }',
+      // Browser that supports private fields but not `in` on them - see es-versions.md
       options: [{ overrideBrowserslist: 'Chrome >= 90' }],
       errors: [{ message: 'ES2022 private in (`#field in object`) is forbidden.' }],
     },

--- a/packages/eslint-plugin-ecmascript-compat/lib/features/es2022.spec.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/features/es2022.spec.js
@@ -7,84 +7,72 @@ const ruleTester = new RuleTester({
   },
 });
 
-const chrome71Options = { overrideBrowserslist: 'Chrome >= 71' };
-const chrome90Options = { overrideBrowserslist: 'Chrome >= 90' };
+// Browser that doesn't support any features of this version - see es-versions.md
+process.env.BROWSERSLIST = 'Chrome >= 71';
+jest.resetModules();
 
 ruleTester.run('compat', require('../rule'), {
   valid: [
     {
       code: '[].at(1);',
-      options: [
-        { ...chrome71Options, polyfills: ['{Array,String,TypedArray}.prototype.at'] },
-      ],
+      options: [{ polyfills: ['{Array,String,TypedArray}.prototype.at'] }],
     },
     {
       code: '"Foo".at(1);',
-      options: [
-        { ...chrome71Options, polyfills: ['{Array,String,TypedArray}.prototype.at'] },
-      ],
+      options: [{ polyfills: ['{Array,String,TypedArray}.prototype.at'] }],
     },
     {
       code: "new Error('message', { cause: originalError })",
-      options: [{ ...chrome71Options, polyfills: ['Error.cause'] }],
+      options: [{ polyfills: ['Error.cause'] }],
     },
     {
       code: "Object.hasOwn(obj, 'prop');",
-      options: [{ ...chrome71Options, polyfills: ['Object.hasOwn'] }],
+      options: [{ polyfills: ['Object.hasOwn'] }],
     },
   ],
   invalid: [
     {
       // Obvious array, doesn't need aggressive mode
       code: '[].at(1);',
-      options: [chrome71Options],
       errors: [{ message: "ES2022 'Array.prototype.at' method is forbidden." }],
     },
     {
       // Obvious string, doesn't need aggressive mode
       code: '"Foo".at(1);',
-      options: [chrome71Options],
       errors: [{ message: "ES2022 'String.prototype.at' method is forbidden." }],
     },
     {
       // Not obvious, needs aggressive mode
       code: 'foo.at(1);',
-      options: [chrome71Options],
       errors: [{ message: "ES2022 'Array.prototype.at' method is forbidden." }],
     },
     {
       code: 'class A { a = 0 }',
-      options: [chrome71Options],
       errors: [{ message: "ES2020 field 'a' is forbidden." }],
     },
     {
       code: 'class A { static { } }',
-      options: [chrome71Options],
       errors: [{ message: 'ES2022 class static block is forbidden.' }],
     },
     {
       code: "new Error('message', { cause: originalError })",
-      options: [chrome71Options],
       errors: [{ message: 'ES2022 Error Cause is forbidden.' }],
     },
     {
       code: "Object.hasOwn(obj, 'prop');",
-      options: [chrome71Options],
       errors: [{ message: "ES2022 'Object.hasOwn' method is forbidden." }],
     },
     {
       code: '/./d;',
-      options: [chrome71Options],
       errors: [{ message: "ES2022 RegExp 'd' flag is forbidden." }],
     },
     {
       code: 'await true;',
-      options: [chrome71Options],
       errors: [{ message: "ES2022 top-level 'await' is forbidden." }],
     },
     {
       code: 'class A { #field; foo() { #field in this; } }',
-      options: [chrome90Options],
+      options: [{ overrideBrowserslist: 'Chrome >= 90' }],
       errors: [{ message: 'ES2022 private in (`#field in object`) is forbidden.' }],
     },
   ],

--- a/packages/eslint-plugin-ecmascript-compat/lib/rule.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/rule.js
@@ -46,18 +46,7 @@ module.exports = {
           },
           browserslistOptions: {
             type: 'object',
-            properties: {
-              config: {
-                type: 'string',
-              },
-              path: {
-                type: 'string',
-              },
-              env: {
-                type: 'string',
-              },
-            },
-            additionalProperties: false,
+            additionalProperties: true,
           },
         },
         additionalProperties: false,

--- a/packages/eslint-plugin-ecmascript-compat/lib/rule.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/rule.js
@@ -3,9 +3,6 @@ const { createDelegatee, delegatingVisitor } = require('./delegation');
 const features = require('./features');
 const targetRuntimes = require('./targetRuntimes');
 
-const targets = targetRuntimes();
-const unsupportedFeatures = compatibility.unsupportedFeatures(features, targets);
-
 module.exports = {
   meta: {
     type: 'problem',
@@ -44,12 +41,35 @@ module.exports = {
               ],
             },
           },
+          overrideBrowserslist: {
+            oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+          },
+          browserslistOptions: {
+            type: 'object',
+            properties: {
+              config: {
+                type: 'string',
+              },
+              path: {
+                type: 'string',
+              },
+              env: {
+                type: 'string',
+              },
+            },
+            additionalProperties: false,
+          },
         },
         additionalProperties: false,
       },
     ],
   },
   create(context) {
+    const overrideBrowserslist = context.options?.[0]?.overrideBrowserslist;
+    const browserslistOptions = context.options?.[0]?.browserslistOptions;
+    const targets = targetRuntimes(overrideBrowserslist, browserslistOptions);
+    const unsupportedFeatures = compatibility.unsupportedFeatures(features, targets);
+
     const polyfills = context.options?.[0]?.polyfills ?? [];
 
     const visitors = unsupportedFeatures

--- a/packages/eslint-plugin-ecmascript-compat/lib/targetRuntimes.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/targetRuntimes.js
@@ -33,14 +33,7 @@ module.exports = function targetRuntimes(overrideBrowserslist, browserslistOptio
 };
 
 function isKnownFamily(name) {
-  const isKnown = compatData.browsers[name] != null;
-
-  if (!isKnown) {
-    // eslint-disable-next-line no-console
-    console.warn(`es-compat: No compatibility data for target family '${name}'`);
-  }
-
-  return isKnown;
+  return compatData.browsers[name] != null;
 }
 
 // browserslist -> @mdn/browser-compat-data (where necessary and available)

--- a/packages/eslint-plugin-ecmascript-compat/lib/targetRuntimes.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/targetRuntimes.js
@@ -7,13 +7,6 @@ module.exports = function targetRuntimes(overrideBrowserslist, browserslistOptio
   // ['chrome 50', ...]
   const allNamedVersions = browserslist(overrideBrowserslist, browserslistOptions);
 
-  if (allNamedVersions.length === 0) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'es-compat: No browserify configurations found, code will not be checked'
-    );
-  }
-
   // [ { name, version }, ... ]
   const all = allNamedVersions.map((namedVersion) => {
     const [name, version] = namedVersion.split(' ');
@@ -34,9 +27,6 @@ module.exports = function targetRuntimes(overrideBrowserslist, browserslistOptio
 
   const mapped = _.mapKeys(oldestOfEach, (version, name) => mapFamilyName(name));
   const final = _.pickBy(mapped, (version, name) => isKnownFamily(name));
-
-  // eslint-disable-next-line no-console
-  console.log('es-compat: checking compatibility for targets', final);
 
   // [ { name, version } ]
   return Object.entries(final).map(([name, version]) => ({ name, version }));

--- a/packages/eslint-plugin-ecmascript-compat/lib/targetRuntimes.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/targetRuntimes.js
@@ -3,9 +3,16 @@ const _ = require('lodash');
 const compatData = require('@mdn/browser-compat-data');
 const compareVersions = require('./compareVersions');
 
-module.exports = function targetRuntimes() {
+module.exports = function targetRuntimes(overrideBrowserslist, browserslistOptions) {
   // ['chrome 50', ...]
-  const allNamedVersions = browserslist();
+  const allNamedVersions = browserslist(overrideBrowserslist, browserslistOptions);
+
+  if (allNamedVersions.length === 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'es-compat: No browserify configurations found, code will not be checked'
+    );
+  }
 
   // [ { name, version }, ... ]
   const all = allNamedVersions.map((namedVersion) => {

--- a/packages/eslint-plugin-ecmascript-compat/lib/targetRuntimes.spec.js
+++ b/packages/eslint-plugin-ecmascript-compat/lib/targetRuntimes.spec.js
@@ -39,6 +39,13 @@ it('handles multiple families', () => {
   ]);
 });
 
+it('accepts a override', () => {
+  expect(targetRuntimes('Firefox >= 55,IE >= 10')).toEqual([
+    { name: 'firefox', version: '55' },
+    { name: 'ie', version: '10' },
+  ]);
+});
+
 it('preserves versions as strings to allow semver', () => {
   process.env.BROWSERSLIST = 'Node >= 0';
 


### PR DESCRIPTION
We have a number of browserslist environments and would like some files to be scanned using one environment and some with another.

I can only achieve this by clearing the node cache and re-importing the rule.. Most browserslist tools allow you to pass the environment through.

I added the full API options to the eslint rule options for full flexibility.

I've also added a warning if the browsers list comes back empty - we had missed that when we introduced environments, the tool no longer did anything...

One gotcha with the es2022 test was that the rule tester seems to be async but returns void - so initially it didn't work because the environment variable is changed synchronously which works when re-importing the rule, but not when the testing is done async.. but the new options provide a neater way to test different configurations anyway.