### PR TITLE
Implement polyfills option in CLI

### DIFF
--- a/packages/check-es-compat/README.md
+++ b/packages/check-es-compat/README.md
@@ -19,6 +19,16 @@ Firefox >= 58
 
 <!--- Absolute link, in order to work from NPM website --->
 
+The optional `--polyfills` argument can be used to specify polyfills that your application loads. These features are
+therefore considered supported in all browsers. Features that are polyfillable and can be specified here can be found
+in the [rule schema](https://github.com/robatwilliams/es-compat/blob/master/packages/eslint-plugin-ecmascript-compat/lib/rule.js).
+
+```bash
+$ npx check-es-compat . --polyfills="Array.prototype.includes,Promise.prototype.finally"
+```
+
+<!--- Absolute link, in order to work from NPM website --->
+
 It [doesn't currently support](https://github.com/robatwilliams/es-compat/issues/69) ES modules.
 
 <!--- Absolute link, in order to work from NPM website --->

--- a/packages/check-es-compat/bin/cli.mjs
+++ b/packages/check-es-compat/bin/cli.mjs
@@ -17,7 +17,8 @@ if (args.length === 0) {
   }
 }
 
-async function execute(files) {
+async function execute(args) {
+  const { files, polyfills } = parseArguments(args);
   const eslint = new ESLint({
     // Ignore any config files
     useEslintrc: false,
@@ -34,7 +35,7 @@ async function execute(files) {
         es2023: true,
       },
       rules: {
-        'ecmascript-compat/compat': 'error',
+        'ecmascript-compat/compat': ['error', { polyfills }],
       },
     },
   });
@@ -45,4 +46,42 @@ async function execute(files) {
   console.log(formatter.format(results));
 
   return { hasErrors: results.some((result) => result.errorCount > 0) };
+}
+
+function parseArguments(args) {
+    const files = [];
+    const polyfills = [];
+    let nextArgIsPolyfills = false;
+
+    for (const arg of args) {
+        if (nextArgIsPolyfills) {
+            nextArgIsPolyfills = false;
+            polyfills.push(...splitPolyfillsArgument(arg));
+            continue;
+        }
+
+        if (arg.startsWith('--polyfills')) {
+            if (arg.startsWith('--polyfills=')) {
+                polyfills.push(...splitPolyfillsArgument(arg.slice(12)));
+            } else {
+                nextArgIsPolyfills = true;
+            }
+
+            continue;
+        }
+
+        files.push(arg);
+    }
+
+    return { files, polyfills };
+}
+
+function splitPolyfillsArgument(polyfills) {
+    const prototypeAtPolyfill = '{Array,String,TypedArray}.prototype.at';
+    const prototypeAtPlaceholder = '{{PROTOTYPEAT}}';
+
+    return polyfills
+        .replace(prototypeAtPolyfill, prototypeAtPlaceholder)
+        .split(',')
+        .map(polyfill => polyfill === prototypeAtPlaceholder ? prototypeAtPolyfill : polyfill);
 }


### PR DESCRIPTION
This should make it possible to use the functionality introduced in #50 with the CLI.

I'm aware that this implementation is a bit naive in the parsing and such, but I thought it would be overkill to add a new dependency to convert this simple script into a "proper CLI" (something like [minimist](https://www.npmjs.com/package/minimist) for example).